### PR TITLE
Fix auth guard wiring after folder restructuring

### DIFF
--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -3,9 +3,10 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { AnalyticsService } from './analytics.service';
 import { AnalyticsController } from './analytics.controller';
 import { UserActionLog } from './entities/user-action-log.model';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([UserActionLog])],
+  imports: [AuthModule, SequelizeModule.forFeature([UserActionLog])],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],
   exports: [AnalyticsService, SequelizeModule],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Module({
   imports: [ConfigModule],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService],
+  providers: [AuthService, JwtAuthGuard],
+  exports: [AuthService, JwtAuthGuard],
 })
 export class AuthModule {}

--- a/src/feedback/feedback.module.ts
+++ b/src/feedback/feedback.module.ts
@@ -3,9 +3,10 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { FeedbackEntry } from './entities/feedback.model';
 import { FeedbackService } from './feedback.service';
 import { FeedbackController } from './feedback.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([FeedbackEntry])],
+  imports: [AuthModule, SequelizeModule.forFeature([FeedbackEntry])],
   controllers: [FeedbackController],
   providers: [FeedbackService],
   exports: [FeedbackService, SequelizeModule],

--- a/src/loyalty/loyalty.module.ts
+++ b/src/loyalty/loyalty.module.ts
@@ -12,9 +12,11 @@ import { PurchasesService } from './services/purchases.service';
 import { LoyaltyService } from './services/loyalty.service';
 import { DynamicCodeService } from './services/dynamic-code.service';
 import { LoyaltyController } from './loyalty.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
+    AuthModule,
     SequelizeModule.forFeature([
       Purchase,
       DiscountGroup,


### PR DESCRIPTION
## Summary
- export the JWT auth guard from the auth module so other modules can reuse it
- import the auth module wherever guarded controllers live to provide the auth service dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d54fe084e48330a9d6abaac3566233