### PR TITLE
Fix Sequelize typings and module wiring

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -36,14 +36,14 @@ export class AnalyticsService {
       return { total: 0, actions: [] };
     }
 
-    const rows = await this.logModel.findAll({
+    const rows = (await this.logModel.findAll({
       attributes: [
         'action',
         [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
       ],
       group: ['action'],
       raw: true,
-    });
+    })) as unknown as Array<{ action: string; count: string | number | null }>;
 
     const actions = rows.map((row) => ({
       action: row.action,

--- a/src/analytics/entities/user-action-log.model.ts
+++ b/src/analytics/entities/user-action-log.model.ts
@@ -6,6 +6,12 @@ import {
   ForeignKey,
   BelongsTo,
 } from 'sequelize-typescript';
+import type {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { User } from '../../users/user.model';
 
 @Table({
@@ -13,13 +19,16 @@ import { User } from '../../users/user.model';
   timestamps: true,
   updatedAt: false,
 })
-export class UserActionLog extends Model<UserActionLog> {
+export class UserActionLog extends Model<
+  InferAttributes<UserActionLog>,
+  InferCreationAttributes<UserActionLog>
+> {
   @Column({
     type: DataType.INTEGER,
     autoIncrement: true,
     primaryKey: true,
   })
-  declare id: number;
+  declare id: CreationOptional<number>;
 
   @ForeignKey(() => User)
   @Column({
@@ -27,17 +36,17 @@ export class UserActionLog extends Model<UserActionLog> {
     allowNull: true,
     field: 'user_id',
   })
-  declare userId?: number | null;
+  declare userId: CreationOptional<number | null>;
 
   @BelongsTo(() => User)
-  declare user?: User;
+  declare user?: NonAttribute<User>;
 
   @Column({
     type: DataType.STRING,
     allowNull: true,
     field: 'phone_number',
   })
-  declare phoneNumber?: string | null;
+  declare phoneNumber: CreationOptional<string | null>;
 
   @Column({
     type: DataType.STRING,
@@ -49,5 +58,5 @@ export class UserActionLog extends Model<UserActionLog> {
     type: DataType.JSONB,
     allowNull: true,
   })
-  declare metadata?: Record<string, unknown> | null;
+  declare metadata: CreationOptional<Record<string, unknown> | null>;
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,8 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
-import { AuthenticatedRequest, JwtAuthGuard } from './guards/jwt-auth.guard';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import type { AuthenticatedRequest } from './guards/jwt-auth.guard';
 
 @Controller('auth')
 export class AuthController {

--- a/src/feedback/dto/create-feedback.dto.ts
+++ b/src/feedback/dto/create-feedback.dto.ts
@@ -1,5 +1,5 @@
 import { IsIn, IsNotEmpty, IsString, MaxLength } from 'class-validator';
-import { FeedbackContactPreference } from '../feedback.types';
+import type { FeedbackContactPreference } from '../feedback.types';
 
 export class CreateFeedbackDto {
   @IsString()

--- a/src/feedback/entities/feedback.model.ts
+++ b/src/feedback/entities/feedback.model.ts
@@ -1,17 +1,25 @@
 import { Table, Column, Model, DataType } from 'sequelize-typescript';
+import type {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+} from 'sequelize';
 
 @Table({
   tableName: 'feedback_entries',
   timestamps: true,
   updatedAt: false,
 })
-export class FeedbackEntry extends Model<FeedbackEntry> {
+export class FeedbackEntry extends Model<
+  InferAttributes<FeedbackEntry>,
+  InferCreationAttributes<FeedbackEntry>
+> {
   @Column({
     type: DataType.INTEGER,
     autoIncrement: true,
     primaryKey: true,
   })
-  declare id: number;
+  declare id: CreationOptional<number>;
 
   @Column({
     type: DataType.STRING,

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { FeedbackEntry } from './entities/feedback.model';
-import { FeedbackContactPreference } from './feedback.types';
+import type { FeedbackContactPreference } from './feedback.types';
 
 export interface FeedbackPayload {
   phoneNumber: string;

--- a/src/loyalty/entities/discount-group.model.ts
+++ b/src/loyalty/entities/discount-group.model.ts
@@ -1,11 +1,19 @@
 import { Table, Column, Model, DataType, HasMany } from 'sequelize-typescript';
+import type {
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { DiscountItem } from './discount-item.model';
 
 @Table({
   tableName: 'discount_groups',
   timestamps: false,
 })
-export class DiscountGroup extends Model<DiscountGroup> {
+export class DiscountGroup extends Model<
+  InferAttributes<DiscountGroup, { omit: 'items' }>,
+  InferCreationAttributes<DiscountGroup, { omit: 'items' }>
+> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
@@ -19,5 +27,5 @@ export class DiscountGroup extends Model<DiscountGroup> {
   declare title: string;
 
   @HasMany(() => DiscountItem)
-  declare items?: DiscountItem[];
+  declare items?: NonAttribute<DiscountItem[]>;
 }

--- a/src/loyalty/entities/discount-item.model.ts
+++ b/src/loyalty/entities/discount-item.model.ts
@@ -6,13 +6,21 @@ import {
   ForeignKey,
   BelongsTo,
 } from 'sequelize-typescript';
+import type {
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { DiscountGroup } from './discount-group.model';
 
 @Table({
   tableName: 'discount_items',
   timestamps: false,
 })
-export class DiscountItem extends Model<DiscountItem> {
+export class DiscountItem extends Model<
+  InferAttributes<DiscountItem, { omit: 'group' }>,
+  InferCreationAttributes<DiscountItem, { omit: 'group' }>
+> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
@@ -28,7 +36,7 @@ export class DiscountItem extends Model<DiscountItem> {
   declare groupId: string;
 
   @BelongsTo(() => DiscountGroup)
-  declare group?: DiscountGroup;
+  declare group?: NonAttribute<DiscountGroup>;
 
   @Column({
     type: DataType.STRING,

--- a/src/loyalty/entities/region-location.model.ts
+++ b/src/loyalty/entities/region-location.model.ts
@@ -6,13 +6,21 @@ import {
   ForeignKey,
   BelongsTo,
 } from 'sequelize-typescript';
+import type {
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { RegionNetwork } from './region-network.model';
 
 @Table({
   tableName: 'region_locations',
   timestamps: false,
 })
-export class RegionLocation extends Model<RegionLocation> {
+export class RegionLocation extends Model<
+  InferAttributes<RegionLocation, { omit: 'network' }>,
+  InferCreationAttributes<RegionLocation, { omit: 'network' }>
+> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
@@ -28,7 +36,7 @@ export class RegionLocation extends Model<RegionLocation> {
   declare networkId: string;
 
   @BelongsTo(() => RegionNetwork)
-  declare network?: RegionNetwork;
+  declare network?: NonAttribute<RegionNetwork>;
 
   @Column({
     type: DataType.STRING,

--- a/src/loyalty/entities/region-network.model.ts
+++ b/src/loyalty/entities/region-network.model.ts
@@ -7,6 +7,11 @@ import {
   BelongsTo,
   HasMany,
 } from 'sequelize-typescript';
+import type {
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { Region } from './region.model';
 import { RegionLocation } from './region-location.model';
 
@@ -14,7 +19,10 @@ import { RegionLocation } from './region-location.model';
   tableName: 'region_networks',
   timestamps: false,
 })
-export class RegionNetwork extends Model<RegionNetwork> {
+export class RegionNetwork extends Model<
+  InferAttributes<RegionNetwork, { omit: 'region' | 'locations' }>,
+  InferCreationAttributes<RegionNetwork, { omit: 'region' | 'locations' }>
+> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
@@ -30,7 +38,7 @@ export class RegionNetwork extends Model<RegionNetwork> {
   declare regionId: string;
 
   @BelongsTo(() => Region)
-  declare region?: Region;
+  declare region?: NonAttribute<Region>;
 
   @Column({
     type: DataType.STRING,
@@ -39,5 +47,5 @@ export class RegionNetwork extends Model<RegionNetwork> {
   declare title: string;
 
   @HasMany(() => RegionLocation)
-  declare locations?: RegionLocation[];
+  declare locations?: NonAttribute<RegionLocation[]>;
 }

--- a/src/loyalty/entities/region.model.ts
+++ b/src/loyalty/entities/region.model.ts
@@ -1,11 +1,19 @@
 import { Table, Column, Model, DataType, HasMany } from 'sequelize-typescript';
+import type {
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { RegionNetwork } from './region-network.model';
 
 @Table({
   tableName: 'regions',
   timestamps: false,
 })
-export class Region extends Model<Region> {
+export class Region extends Model<
+  InferAttributes<Region, { omit: 'networks' }>,
+  InferCreationAttributes<Region, { omit: 'networks' }>
+> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
@@ -19,5 +27,5 @@ export class Region extends Model<Region> {
   declare title: string;
 
   @HasMany(() => RegionNetwork)
-  declare networks?: RegionNetwork[];
+  declare networks?: NonAttribute<RegionNetwork[]>;
 }

--- a/src/loyalty/loyalty.module.ts
+++ b/src/loyalty/loyalty.module.ts
@@ -13,10 +13,12 @@ import { LoyaltyService } from './services/loyalty.service';
 import { DynamicCodeService } from './services/dynamic-code.service';
 import { LoyaltyController } from './loyalty.controller';
 import { AuthModule } from '../auth/auth.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     AuthModule,
+    UsersModule,
     SequelizeModule.forFeature([
       Purchase,
       DiscountGroup,


### PR DESCRIPTION
## Summary
- update Sequelize models to use explicit attribute and creation typings, enabling strict `create` calls
- adjust analytics service raw query handling and type-only imports required under isolated modules
- wire `UsersModule` into `LoyaltyModule` so `UsersService` dependencies resolve correctly

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d555fdd41c8330b5729994504b8e78