### PR TITLE
Fix discount item ordering association

### DIFF
--- a/src/loyalty/services/discount-catalog.service.ts
+++ b/src/loyalty/services/discount-catalog.service.ts
@@ -22,12 +22,13 @@ export class DiscountCatalogService {
       include: [
         {
           model: DiscountItem,
+          as: 'items',
           attributes: ['id', 'title'],
         },
       ],
       order: [
         ['title', 'ASC'],
-        [DiscountItem, 'title', 'ASC'],
+        [{ model: DiscountItem, as: 'items' }, 'title', 'ASC'],
       ],
     });
   }
@@ -40,10 +41,11 @@ export class DiscountCatalogService {
       include: [
         {
           model: DiscountItem,
+          as: 'items',
           attributes: ['id', 'title'],
         },
       ],
-      order: [[DiscountItem, 'title', 'ASC']],
+      order: [[{ model: DiscountItem, as: 'items' }, 'title', 'ASC']],
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure discount items association is referenced via the registered alias in catalog queries
- keep nested discount items ordered alphabetically when fetching groups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d585b1c42c8330a54ffc152374cc01