### PR TITLE
Fix monthly range calculation for purchases stats

### DIFF
--- a/src/loyalty/services/purchases.service.ts
+++ b/src/loyalty/services/purchases.service.ts
@@ -38,19 +38,14 @@ export class PurchasesService {
   }
 
   private getMonthRange(referenceDate: Date) {
-    const start = new Date(
-      referenceDate.getFullYear(),
-      referenceDate.getMonth(),
-      1,
-    )
+    const year = referenceDate.getFullYear();
+    const monthIndex = referenceDate.getMonth();
+
+    const start = new Date(Date.UTC(year, monthIndex, 1))
       .toISOString()
       .slice(0, 10);
 
-    const endDate = new Date(
-      referenceDate.getFullYear(),
-      referenceDate.getMonth() + 1,
-      0,
-    )
+    const endDate = new Date(Date.UTC(year, monthIndex + 1, 0))
       .toISOString()
       .slice(0, 10);
 


### PR DESCRIPTION
## Summary
- compute monthly range boundaries in UTC to avoid timezone-dependent shifts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d632a2b3e88330b30fd412d6e95629