### PR TITLE
Restrict backend compiler scope to avoid frontend TypeScript errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist
 /node_modules
+/frontend/node_modules
+/frontend/dist
 /build
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ NestJS сервіс для програми лояльності мережі А
 | `TELEGRAM_WEBHOOK_PATH` | Шлях вебхука (за замовчуванням `/telegram/webhook`). Використовуйте унікальний секретний сегмент. |
 | `TELEGRAM_WEBHOOK_SECRET` | Необов'язковий секрет для заголовка `X-Telegram-Bot-Api-Secret-Token`. |
 | `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, `AUTH_JWT_SECRET`, `AUTH_TOKEN_TTL` | Налаштування API-авторизації. `AUTH_TOKEN_TTL` за замовчуванням 3600 секунд. |
+| `ADMIN_FRONTEND_ORIGINS` | Кома-сепарований список дозволених origin для CORS (напр., `https://admin.example.com`). Значення `*` дозволяє всі походження. |
 | `PORT` | Порт HTTP сервера (за замовчуванням 3000). |
 | `DB_LOGGING` | Встановіть `true`, щоб бачити SQL у логах. |
 
@@ -68,6 +69,29 @@ NestJS сервіс для програми лояльності мережі А
 | `GET` | `/admin/analytics` | Узагальнена статистика використання бота. |
 
 Усі запити (окрім `/auth/login`) потребують заголовок `Authorization: Bearer <token>`.
+
+## Адмінський фронтенд (Vite + Vue)
+
+Для роботи адміністративної панелі статистики фронтенд винесено в окремий проєкт на Vite/Vue у каталозі [`frontend`](./frontend).
+
+### Локальний запуск
+
+1. Перейдіть у директорію фронтенду та встановіть залежності:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Запустіть дев-сервер Vite (за замовчуванням порт `5173`):
+   ```bash
+   npm run dev
+   ```
+3. Переконайтесь, що бекенд запущено на `http://localhost:3000`. Vite автоматично проксуватиме запити `/auth/*` та `/admin/*` до бекенду.
+
+> **ENV.** Для розміщення фронтенду окремо від бекенду задайте `VITE_API_BASE_URL` (напр., `https://api.example.com`). На бекенді вкажіть `ADMIN_FRONTEND_ORIGINS`, перелік дозволених origin через кому (напр., `https://admin.example.com,https://staging-admin.example.com`). Значення `*` відкриває доступ для будь-якого origin.
+
+### Продакшн-збірка
+
+Виконайте `npm run build` у папці `frontend` — збірка з’явиться у `frontend/dist`. Статичні файли можна задеплоїти на CDN або будь-який static hosting.
 
 ### Формат відповіді `/user-info`
 

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>;
+  export default component;
+}
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Аналітика програми лояльності</title>
+    <meta
+      name="description"
+      content="Адміністративна панель для перегляду статистики використання бота лояльності"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "loyalty-admin-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.12"
+  },
+  "devDependencies": {
+    "@tsconfig/strictest": "^2.0.5",
+    "@vitejs/plugin-vue": "^5.1.4",
+    "typescript": "^5.7.3",
+    "vite": "^5.4.11",
+    "vue-tsc": "^2.1.10"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="page">
+    <main class="content">
+      <transition name="fade" mode="out-in">
+        <LoginView
+          v-if="!isAuthenticated"
+          :key="'login'"
+          :loading="loading"
+          :error="errorMessage"
+          @submit="handleLogin"
+        />
+        <DashboardView
+          v-else
+          :key="'dashboard'"
+          @session-expired="handleSessionExpired"
+          @logged-out="handleLoggedOut"
+        />
+      </transition>
+      <p v-if="infoMessage" class="info" role="status">{{ infoMessage }}</p>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import LoginView from './views/LoginView.vue';
+import DashboardView from './views/DashboardView.vue';
+import {
+  isAuthenticated as isAuthenticatedState,
+  login as loginStore,
+  logout as logoutStore,
+} from './stores/authStore';
+
+const isAuthenticated = computed(() => isAuthenticatedState.value);
+const loading = ref(false);
+const errorMessage = ref<string | null>(null);
+const infoMessage = ref<string | null>(null);
+
+async function handleLogin(payload: { clientId: string; clientSecret: string }) {
+  if (loading.value) {
+    return;
+  }
+
+  loading.value = true;
+  errorMessage.value = null;
+  infoMessage.value = null;
+
+  try {
+    const message = await loginStore(payload.clientId, payload.clientSecret);
+    infoMessage.value = message;
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Не вдалося виконати авторизацію.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleSessionExpired() {
+  await logoutStore();
+  infoMessage.value = null;
+  errorMessage.value = 'Сесію завершено. Будь ласка, авторизуйтеся повторно.';
+}
+
+function handleLoggedOut() {
+  infoMessage.value = 'Сесію завершено.';
+  errorMessage.value = null;
+}
+</script>
+
+<style scoped>
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(139, 92, 246, 0.2), transparent 50%),
+    linear-gradient(160deg, #0f172a 0%, #1e293b 100%);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+}
+
+.info {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  color: #1d4ed8;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/api/analyticsApi.ts
+++ b/frontend/src/api/analyticsApi.ts
@@ -1,0 +1,13 @@
+import { requestJson } from './httpClient';
+import type { UsageSummary } from '../types/analytics';
+
+export interface UsageSummaryResponse {
+  message: string;
+  summary: UsageSummary;
+}
+
+export async function fetchUsageSummary(authToken: string) {
+  return requestJson<UsageSummaryResponse>('/admin/analytics', {
+    authToken,
+  });
+}

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -1,0 +1,27 @@
+import { requestJson } from './httpClient';
+
+export interface LoginPayload {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  tokenType: string;
+  expiresIn: number;
+  message: string;
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  return requestJson<LoginResponse>('/auth/login', {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export async function logout(authToken: string) {
+  return requestJson<{ message: string }>('/auth/logout', {
+    method: 'POST',
+    authToken,
+  });
+}

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -1,0 +1,61 @@
+export class HttpError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(message: string, status: number, details: unknown) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export interface RequestOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  body?: unknown;
+  authToken?: string | null;
+  signal?: AbortSignal;
+}
+
+const baseUrl = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+
+export async function requestJson<TResponse>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<TResponse> {
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+  const headers = new Headers();
+
+  if (options.body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (options.authToken) {
+    headers.set('Authorization', `Bearer ${options.authToken}`);
+  }
+
+  const response = await fetch(url, {
+    method: options.method ?? 'GET',
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    headers,
+    signal: options.signal,
+    credentials: 'include',
+  });
+
+  const contentType = response.headers.get('content-type');
+  const payload =
+    contentType && contentType.includes('application/json')
+      ? await response.json()
+      : await response.text();
+
+  if (!response.ok) {
+    const message =
+      typeof payload === 'object' && payload !== null && 'message' in payload
+        ? String((payload as { message: unknown }).message)
+        : `HTTP ${response.status}`;
+
+    throw new HttpError(message, response.status, payload);
+  }
+
+  return payload as TResponse;
+}

--- a/frontend/src/components/AnalyticsSummaryTable.vue
+++ b/frontend/src/components/AnalyticsSummaryTable.vue
@@ -1,0 +1,127 @@
+<template>
+  <section class="summary-card" aria-live="polite">
+    <header class="summary-header">
+      <div>
+        <h2>Активність користувачів</h2>
+        <p class="summary-subtitle">Загальна кількість дій: <strong>{{ summary.total }}</strong></p>
+      </div>
+      <button class="refresh" type="button" @click="$emit('refresh')" :disabled="loading">
+        <span v-if="loading">Оновлення...</span>
+        <span v-else>Оновити</span>
+      </button>
+    </header>
+
+    <table v-if="summary.actions.length" class="summary-table">
+      <thead>
+        <tr>
+          <th scope="col">Дія</th>
+          <th scope="col">Кількість</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in summary.actions" :key="item.action">
+          <td>{{ item.action }}</td>
+          <td>{{ item.count }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else class="empty">Ще не зафіксовано жодної події.</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { UsageSummary } from '../types/analytics';
+
+defineProps<{ summary: UsageSummary; loading?: boolean }>();
+
+defineEmits<{ refresh: [] }>();
+</script>
+
+<style scoped>
+.summary-card {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 24px;
+  backdrop-filter: blur(14px);
+  color: #0f172a;
+  background-color: rgba(248, 250, 252, 0.9);
+}
+
+.summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.summary-subtitle {
+  margin: 4px 0 0;
+  color: #475569;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 12px 8px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.summary-table th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.refresh {
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.refresh:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.refresh:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+}
+
+.empty {
+  margin: 0;
+  color: #64748b;
+}
+
+@media (max-width: 640px) {
+  .summary-card {
+    padding: 16px;
+  }
+
+  .summary-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .refresh {
+    align-self: stretch;
+    width: 100%;
+    text-align: center;
+  }
+}
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './styles/base.css';
+
+const app = createApp(App);
+
+app.mount('#app');

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,0 +1,76 @@
+import { computed, reactive } from 'vue';
+import { login as loginApi, logout as logoutApi } from '../api/authApi';
+
+interface AuthState {
+  accessToken: string | null;
+  expiresAt: number | null;
+}
+
+const STORAGE_TOKEN_KEY = 'loyalty-admin-token';
+const STORAGE_EXPIRES_KEY = 'loyalty-admin-token-expires-at';
+
+const storage = typeof window !== 'undefined' ? window.localStorage : null;
+
+function readInitialState(): AuthState {
+  const rawToken = storage?.getItem(STORAGE_TOKEN_KEY) ?? null;
+  const rawExpiresAt = storage?.getItem(STORAGE_EXPIRES_KEY) ?? null;
+
+  return {
+    accessToken: rawToken,
+    expiresAt: rawExpiresAt ? Number.parseInt(rawExpiresAt, 10) : null,
+  };
+}
+
+const state = reactive<AuthState>(readInitialState());
+
+export const isAuthenticated = computed(() => {
+  if (!state.accessToken || !state.expiresAt) {
+    return false;
+  }
+
+  if (Date.now() > state.expiresAt) {
+    clearSession();
+    return false;
+  }
+
+  return true;
+});
+
+export function getAccessToken() {
+  return isAuthenticated.value ? state.accessToken : null;
+}
+
+export async function login(clientId: string, clientSecret: string) {
+  const response = await loginApi({ clientId, clientSecret });
+  const expiresAt = Date.now() + response.expiresIn * 1000;
+
+  state.accessToken = response.token;
+  state.expiresAt = expiresAt;
+
+  storage?.setItem(STORAGE_TOKEN_KEY, response.token);
+  storage?.setItem(STORAGE_EXPIRES_KEY, String(expiresAt));
+
+  return response.message;
+}
+
+export async function logout() {
+  const token = state.accessToken;
+
+  if (token) {
+    try {
+      await logoutApi(token);
+    } catch (error) {
+      // Ігноруємо помилки завершення сесії, оскільки токен буде видалений локально.
+      console.warn('Не вдалося коректно завершити сесію на сервері.', error);
+    }
+  }
+
+  clearSession();
+}
+
+function clearSession() {
+  state.accessToken = null;
+  state.expiresAt = null;
+  storage?.removeItem(STORAGE_TOKEN_KEY);
+  storage?.removeItem(STORAGE_EXPIRES_KEY);
+}

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -1,0 +1,28 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: #0f172a;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,0 +1,9 @@
+export interface UsageSummaryItem {
+  action: string;
+  count: number;
+}
+
+export interface UsageSummary {
+  total: number;
+  actions: UsageSummaryItem[];
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,0 +1,153 @@
+<template>
+  <section class="dashboard">
+    <header class="dashboard-header">
+      <div>
+        <h1>Аналітика використання</h1>
+        <p class="tagline">Оперативні метрики взаємодії користувачів із ботом лояльності.</p>
+      </div>
+      <button class="logout" type="button" @click="onLogout" :disabled="logoutInProgress">
+        {{ logoutInProgress ? 'Вихід...' : 'Вийти' }}
+      </button>
+    </header>
+
+    <AnalyticsSummaryTable
+      :summary="summary"
+      :loading="loading"
+      @refresh="loadSummary"
+    />
+
+    <p v-if="error" class="error" role="alert">{{ error }}</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, onMounted } from 'vue';
+import AnalyticsSummaryTable from '../components/AnalyticsSummaryTable.vue';
+import { fetchUsageSummary } from '../api/analyticsApi';
+import { getAccessToken, logout } from '../stores/authStore';
+import type { UsageSummary } from '../types/analytics';
+import { HttpError } from '../api/httpClient';
+
+const emit = defineEmits<{
+  'session-expired': [];
+  'logged-out': [];
+}>();
+
+const summary = reactive<UsageSummary>({ total: 0, actions: [] });
+const loading = ref(false);
+const error = ref<string | null>(null);
+const logoutInProgress = ref(false);
+
+async function loadSummary() {
+  const token = getAccessToken();
+
+  if (!token) {
+    emit('session-expired');
+    return;
+  }
+
+  loading.value = true;
+  error.value = null;
+
+  try {
+    const response = await fetchUsageSummary(token);
+    summary.total = response.summary.total;
+    summary.actions = [...response.summary.actions];
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 401) {
+      emit('session-expired');
+      return;
+    }
+
+    error.value = err instanceof Error ? err.message : 'Не вдалося отримати дані.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function onLogout() {
+  if (logoutInProgress.value) {
+    return;
+  }
+
+  logoutInProgress.value = true;
+  await logout();
+  logoutInProgress.value = false;
+  emit('logged-out');
+}
+
+onMounted(() => {
+  void loadSummary();
+});
+</script>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 32px;
+  background: rgba(248, 250, 252, 0.8);
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.4);
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.tagline {
+  margin: 4px 0 0;
+  color: #475569;
+}
+
+.logout {
+  border: none;
+  padding: 10px 18px;
+  border-radius: 12px;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.logout:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.logout:not(:disabled):hover {
+  background: rgba(30, 41, 59, 0.9);
+}
+
+.error {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  color: #b91c1c;
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 24px;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .logout {
+    align-self: stretch;
+    width: 100%;
+  }
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,166 @@
+<template>
+  <section class="card" aria-labelledby="login-title">
+    <header class="card-header">
+      <h1 id="login-title">Вхід до панелі аналітики</h1>
+      <p class="subtitle">
+        Використайте виданий вам <strong>clientId</strong> та <strong>clientSecret</strong>, щоб отримати
+        токен доступу до API.
+      </p>
+    </header>
+
+    <form class="form" @submit.prevent="onSubmit">
+      <label class="field">
+        <span>Client ID</span>
+        <input
+          v-model.trim="clientId"
+          type="text"
+          name="clientId"
+          autocomplete="off"
+          required
+          :disabled="loading"
+        />
+      </label>
+
+      <label class="field">
+        <span>Client Secret</span>
+        <input
+          v-model.trim="clientSecret"
+          type="password"
+          name="clientSecret"
+          autocomplete="off"
+          required
+          :disabled="loading"
+        />
+      </label>
+
+      <button class="submit" type="submit" :disabled="loading">
+        <span v-if="loading">Авторизація...</span>
+        <span v-else>Увійти</span>
+      </button>
+
+      <p v-if="error" class="error" role="alert">{{ error }}</p>
+    </form>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+const props = defineProps<{ loading: boolean; error: string | null }>();
+const emit = defineEmits<{
+  submit: [payload: { clientId: string; clientSecret: string }];
+}>();
+
+const clientId = ref('');
+const clientSecret = ref('');
+const error = ref<string | null>(props.error);
+
+watch(
+  () => props.error,
+  (newValue) => {
+    error.value = newValue;
+  },
+);
+
+function onSubmit() {
+  if (!clientId.value || !clientSecret.value) {
+    error.value = 'Будь ласка, заповніть усі поля.';
+    return;
+  }
+
+  error.value = null;
+  emit('submit', { clientId: clientId.value, clientSecret: clientSecret.value });
+}
+</script>
+
+<style scoped>
+.card {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 32px;
+  max-width: 420px;
+  width: 100%;
+  color: #f8fafc;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
+}
+
+.card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.field input {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.submit {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #fff;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 15px 35px rgba(99, 102, 241, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.submit:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.4);
+}
+
+.error {
+  margin: 0;
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+@media (max-width: 520px) {
+  .card {
+    padding: 24px;
+  }
+}
+</style>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "esnext",
+    "jsx": "preserve",
+    "lib": ["esnext", "dom"],
+    "types": ["vite/client"],
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "env.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/auth': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      '/admin': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,19 @@ async function bootstrap() {
     }),
   );
   const configService = app.get(ConfigService);
+  const adminOrigins = configService.get<string>('ADMIN_FRONTEND_ORIGINS');
+  const allowedOrigins = adminOrigins
+    ? adminOrigins
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0)
+    : ['http://localhost:5173'];
+  const allowAnyOrigin = allowedOrigins.includes('*');
+
+  app.enableCors({
+    origin: allowAnyOrigin ? true : allowedOrigins,
+    credentials: true,
+  });
   const webhookDomain = configService.get<string>('TELEGRAM_WEBHOOK_DOMAIN');
 
   if (webhookDomain) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src/**/*", "test/**/*", "scripts/**/*"],
+  "exclude": ["frontend", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- limit the root TypeScript project to backend and tooling sources so it no longer compiles the new frontend app
- exclude the frontend directory to prevent NodeNext resolution errors when running backend tooling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da86f977d48330bf6f85ebb1ac774e